### PR TITLE
Implement access UI

### DIFF
--- a/lib/bloc/auth_bloc.dart
+++ b/lib/bloc/auth_bloc.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../models/app_user.dart';
+import '../../auth_repository.dart';
+
+abstract class AuthState {}
+class AuthInitial extends AuthState {}
+class Authenticated extends AuthState {
+  final AppUser user;
+  Authenticated(this.user);
+}
+class Unauthenticated extends AuthState {}
+
+class AuthBloc extends Cubit<AuthState> {
+  final AuthRepository _repository;
+  AuthBloc(this._repository) : super(AuthInitial()) {
+    _repository.user.listen((user) {
+      if (user != null) {
+        emit(Authenticated(user));
+      } else {
+        emit(Unauthenticated());
+      }
+    });
+  }
+
+  Future<void> signOut() => _repository.signOut();
+}

--- a/lib/models/app_user.dart
+++ b/lib/models/app_user.dart
@@ -1,0 +1,15 @@
+class AppUser {
+  final String uid;
+  final String? email;
+  final String? displayName;
+
+  AppUser({required this.uid, this.email, this.displayName});
+
+  factory AppUser.fromFirebase(dynamic user) {
+    return AppUser(
+      uid: user.uid,
+      email: user.email,
+      displayName: user.displayName,
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../bloc/auth_bloc.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Home'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.exit_to_app),
+            onPressed: () {
+              context.read<AuthBloc>().signOut();
+            },
+          )
+        ],
+      ),
+      body: const Center(
+        child: Text('Welcome to CAMS-F'),
+      ),
+    );
+  }
+}

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../auth_repository.dart';
+import '../bloc/auth_bloc.dart';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  bool _loading = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final repo = AuthRepository();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            TextField(
+              controller: _passwordController,
+              decoration: const InputDecoration(labelText: 'Password'),
+              obscureText: true,
+            ),
+            const SizedBox(height: 16),
+            if (_loading) const CircularProgressIndicator(),
+            if (!_loading)
+              ElevatedButton(
+                onPressed: () async {
+                  setState(() => _loading = true);
+                  try {
+                    final user = await repo.signInWithEmailAndPassword(
+                      email: _emailController.text,
+                      password: _passwordController.text,
+                    );
+                    context.read<AuthBloc>().emit(Authenticated(user));
+                  } catch (e) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text(e.toString())),
+                    );
+                  } finally {
+                    setState(() => _loading = false);
+                  }
+                },
+                child: const Text('Login'),
+              ),
+            TextButton(
+              onPressed: () {
+                Navigator.pushNamed(context, '/register');
+              },
+              child: const Text('Register'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/register_screen.dart
+++ b/lib/screens/register_screen.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../auth_repository.dart';
+import '../bloc/auth_bloc.dart';
+
+class RegisterScreen extends StatefulWidget {
+  const RegisterScreen({super.key});
+
+  @override
+  State<RegisterScreen> createState() => _RegisterScreenState();
+}
+
+class _RegisterScreenState extends State<RegisterScreen> {
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  final TextEditingController _displayNameController = TextEditingController();
+  bool _loading = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final repo = AuthRepository();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Register')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _displayNameController,
+              decoration: const InputDecoration(labelText: 'Name'),
+            ),
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            TextField(
+              controller: _passwordController,
+              decoration: const InputDecoration(labelText: 'Password'),
+              obscureText: true,
+            ),
+            const SizedBox(height: 16),
+            if (_loading) const CircularProgressIndicator(),
+            if (!_loading)
+              ElevatedButton(
+                onPressed: () async {
+                  setState(() => _loading = true);
+                  try {
+                    final user = await repo.registerWithEmailAndPassword(
+                      email: _emailController.text,
+                      password: _passwordController.text,
+                      displayName: _displayNameController.text,
+                    );
+                    context.read<AuthBloc>().emit(Authenticated(user));
+                    Navigator.pop(context);
+                  } catch (e) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text(e.toString())),
+                    );
+                  } finally {
+                    setState(() => _loading = false);
+                  }
+                },
+                child: const Text('Create Account'),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/main.dart
+++ b/main.dart
@@ -1,19 +1,20 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:firebase_core/firebase_core.dart';
-import 'package:cams_f/core/auth/auth_bloc.dart'; // Ejemplo de import
+import 'auth_repository.dart';
+import 'lib/bloc/auth_bloc.dart';
+import 'lib/screens/login_screen.dart';
+import 'lib/screens/register_screen.dart';
+import 'lib/screens/home_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  
-  // Inicializa Firebase
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform, // Configuración desde flutterfire_cli
-  );
+  await Firebase.initializeApp();
 
   runApp(
     MultiBlocProvider(
       providers: [
-        BlocProvider(create: (context) => AuthBloc(AuthRepository())),
+        BlocProvider(create: (_) => AuthBloc(AuthRepository())),
       ],
       child: const MyApp(),
     ),
@@ -27,26 +28,17 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'CAMS-F Framework',
-      home: BlocBuilder<AuthBloc, AuthState>(
-        builder: (context, state) {
-          if (state is Authenticated) {
-            return const HomeScreen(); // Pantalla post-login
-          }
-          return const LoginScreen(); // Pantalla de inicio
-        },
-      ),
+      initialRoute: '/',
+      routes: {
+        '/': (context) => BlocBuilder<AuthBloc, AuthState>(
+              builder: (context, state) {
+                if (state is Authenticated) return const HomeScreen();
+                return const LoginScreen();
+              },
+            ),
+        '/register': (context) => const RegisterScreen(),
+        '/home': (context) => const HomeScreen(),
+      },
     );
   }
 }
-MaterialApp(
-  routes: {
-    '/': (context) => BlocBuilder<AuthBloc, AuthState>(
-          builder: (context, state) {
-            if (state is Authenticated) return const HomeScreen();
-            return const LoginScreen();
-          },
-        ),
-    '/register': (context) => const RegisterScreen(),
-    '/home': (context) => const HomeScreen(),
-  },
-);


### PR DESCRIPTION
## Summary
- build a simple login/registration/home UI
- manage authentication state with `AuthBloc`
- define an `AppUser` model

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865d607ead0832091e212fa0fb0d6c1